### PR TITLE
For the test the output should have the tag output and not param

### DIFF
--- a/R/galaxy.R
+++ b/R/galaxy.R
@@ -246,7 +246,8 @@ galaxy <-
                 type <- "data"
                 if (length(galaxyItem@formatFilter))
                     xmlAttrs(paramNode)["format"] <- galaxyItem@formatFilter
-
+                else
+                    xmlAttrs(paramNode)["format"] <- "data" #default format of an input file
             }
             if (item$length > 1 || "GalaxySelectParam" %in% class(galaxyItem))
             {

--- a/R/galaxy.R
+++ b/R/galaxy.R
@@ -345,7 +345,10 @@ galaxy <-
         testNode <- newXMLNode("test", parent=testsNode)
         for (info in funcInfo)
         {
-            testParamNode <- newXMLNode("param", parent=testNode)
+            if (info$type == "GalaxyOutput")
+                testParamNode <- newXMLNode("output", parent=testNode)
+            else
+                testParamNode <- newXMLNode("param", parent=testNode)
             xmlAttrs(testParamNode)["name"] <- info$param
             if (length(info$type) > 0 && 
                 info$type %in% c("GalaxyInputFile", "GalaxyOutput"))


### PR DESCRIPTION
Commit 06/02/18:

Hello, I'am trying to use fully RGalaxy, so I want to manage the functional test with Galaxy.

I have tried with you example (add two numbers), but the functional test where not working.

In fact the test don't find the output of the test.
To resolve it I needed to  change the tag of the test output.

So I modify your Galaxy.R script, because for the output of the tests it generated a 'param' tag and not a 'output' tag which is required.

Cf. [https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-tests-test-output](https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-tests-test-output) 

```
if (info$type == "GalaxyOutput")
                testParamNode <- newXMLNode("output", parent=testNode)
            else
                testParamNode <- newXMLNode("param", parent=testNode)
```

____________

Commit Addition 08/02/18:
Add data format by default for the input file tag, when nothing is specified on the formatFilter
